### PR TITLE
Edited and added additional error handling.

### DIFF
--- a/bin/gpt.js
+++ b/bin/gpt.js
@@ -8,7 +8,7 @@ const appendToFile = (file, message, response) => {
   // append to file with the structure {"prompt": messge, "completion": response}
 
   if (!fs.existsSync(file)) {
-    fs.createWriteStream(file).on("open", function (fd) {
+    fs.createWriteStream(file).on("open", function(fd) {
       fs.appendFileSync(
         fd,
         JSON.stringify({ prompt: message, completion: response }) + "\n"
@@ -93,11 +93,32 @@ const generateCompletion = async (apiKey, model, prompt, options) => {
         if (err["response"]["status"] == "429") {
           console.error(
             `${chalk.red(
-              "\nChat GPT is having too many requests, wait and send it again."
+              "\nAPI Rate Limit Exceeded: ChatGPT is getting too many requests from the user in a short period of time. Please wait a while before sending another message."
             )}`
           );
+        }
+        if (err["response"]["status"] == "400") {
+          console.error(
+            `${chalk.red(
+              "\nBad Request: Prompt provided is empty or too long. Prompt should be between 1 and 4096 tokens."
+            )}`
+          );
+        }        
+        if (err["response"]["status"] == "402") {
+          console.error(
+            `${chalk.red(
+              "\nPayment Required: ChatGPT quota exceeded. Please check you chatGPT account."
+            )}`
+          );
+        }
+        if (err["response"]["status"] == "503") {
+          console.error(
+            `${chalk.red(
+              "\nService Unavailable: ChatGPT is currently unavailable, possibly due to maintenance or high traffic. Please try again later."
+            )}`
+          );     
         } else {
-          console.error(`${chalk.red("Something went wrong!!")} ${err}`);
+          console.error(`${chalk.red("Something went wrong!!!")} ${err}`);
         }
 
         spinner.stop();


### PR DESCRIPTION
I found some additional requests that chatGPT commonly returns. I also edited the text to say chatGPT as the company calls it.

400 Bad Request: This status code may be returned when the prompt provided in the request is empty or too long. The prompt should be between 1 and 4096 tokens.

401 Unauthorized: This status code may be returned if the API key provided in the request is invalid, has been revoked, or is not authorized to access the requested resource.

402 Payment Required: This status code may be returned if the user's quota for the API has been exceeded. This means the user has exceeded their monthly usage limit.

429 Too Many Requests: This status code may be returned if the user has sent too many requests in a short period of time. This can occur when the user is sending requests too quickly, and the API rate limit has been exceeded.

500 Internal Server Error: This status code may be returned if there is an internal error on the OpenAI server. This could be caused by a problem with the server or a bug in the API.

503 Service Unavailable: This status code may be returned if the service is currently unavailable, usually because of maintenance or high traffic. This means the service is temporarily down, and the user should try again later.