### PR TITLE
Fixed typo

### DIFF
--- a/bin/intro.js
+++ b/bin/intro.js
@@ -17,7 +17,7 @@ const intro = () => {
   ${duck}
 
   ${chalk.yellowBright("usage:")}
-    TerminalGPT will ask you to add your OpenAI API key. Don't worry, it's saves on your machine locally.
+    TerminalGPT will ask you to add your OpenAI API key. Don't worry, it will be saved on your machine locally.
 
     Terminal will prompt you to enter a message. Type your message and press enter.
     Terminal will then prompt you to enter a response. Type your response and press enter.


### PR DESCRIPTION
Fixed a typo when asking for OpenAI API key in `/bin/intro.js`.
I highly recommend replacing the picture [here](https://www.producthunt.com/products/terminalgpt), as that's where I saw it