### PR TITLE
Enable --engine and --temperature options; fix docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# CONTRIBUTING
+
 ## 😎 Contribute your first spec in < 3 minutes
 
 Use the steps below:
@@ -23,18 +25,6 @@ Use the steps below:
 
    ```
 
-3. On your terminal, type `npm run chat`. Your terminalGPT will start. 😊
+3. On your terminal, type `npm run tgpt -- chat`. Your terminalGPT will start. 😊
 
 <br>
-
-## Extra / Remove from your computer
-
-'npx terminalgpt' doesn't install the terminalgpt package, instead it downloads the package to your pc and directly executes it from the cache.
-
-You can find the package using
-
-`ls ~/.npm/_npx/*/node_modules`
-
-To delete the package, you can use
-
-`rm -r ~/.npm/_npx/*/node_modules/terminalgpt`

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
 Get GPT-like chatGPT on your terminal
 </p>
 
-> Note this doesn't use OpenAI [ChatGPT](https://openai.com/blog/chatgpt/), it uses [text-davinci-003](https://platform.openai.com/docs/models/davinci) model (by default)
-
 ![Screenshot 2023-01-05 at 09 24 10](https://user-images.githubusercontent.com/11979969/210746185-69722c94-b073-4863-82bc-b662236c8305.png)
 
 <p align="center">
@@ -23,18 +21,18 @@ Get GPT-like chatGPT on your terminal
 
 </p>
 
-# Pre-requisite
+## Prerequisites
 
 You'll need to have your own `OpenAi` apikey to operate this package.
 
-1. Go to <https://beta.openai.com>
-2. Select you profile menu and go to `View API Keys`
+1. Go to <https://platform.openai.com>
+2. Select your profile menu and go to `View API Keys`
 3. Select `+ Create new secret key`
 4. Copy generated key
 
-# Get Started
+# Installation
 
-# Using tgpt
+Install terminalGPT globally:
 
 ```bash
 npm -g install terminalgpt
@@ -46,87 +44,50 @@ or
 yarn global add terminalgpt
 ```
 
-## Run
+## Start chat
 
 ```bash
 tgpt chat
 ```
 
-ps.: If it is your first time running it, it will ask for open AI key , `paste generated key from pre-requisite steps`
+PS: If it is your first time running it, it will ask for open AI key, **paste generated key from pre-requisite steps**.
 
-## Changing engine and temperature
+## Options
+
+### Change engine and temperature
 
 ```bash
-tgpt chat --engine "text-davinci-002" --temperature 0.7
+tgpt chat --engine "gpt-4" --temperature 0.7
 ```
 
-### Changing api key
+Note this library uses [Chat Completions API](https://platform.openai.com/docs/api-reference/chat).
+The `engine` parameter is the same as the `model` parameter in the API. The default value is `gpt-3.5-turbo`.
 
-It you are not satisfy or added a wrong api key , run
+### Use markdown
+
+```bash
+tgpt chat --markdown
+```
+
+## Change or delete api key
+
+It you are not satisfied or added a wrong api key, run
 
 ```bash
 tgpt delete
 ```
 
-# Using with npx
+## Using with npx
 
 ```bash
 npx terminalgpt
 ```
 
-## Run
-
 ```bash
-npx terminalgpt chat
+npx terminalgpt <command>
 ```
 
-ps.: If it is your first time running it, it will ask for open AI key , `paste generated key from pre-requisite steps`
-
-### Changing engine and temperature
-
-```bash
-npx terminalgpt chat --engine "text-davinci-002" --temperature 0.7
-```
-
-### Changing api key
-
-If you are not satisfied or entered a wrong api key, run
-
-```
-npx terminalgpt delete
-```
-
-## 😎 Contribute your first spec in < 3 minutes
-
-Use the steps below:
-
-<br/>
-
-**Steps**
-
-1. Click [here](https://github.com/jucasoliveira/terminalGPT/fork) to fork this repo.
-
-2. Clone your forked repo and create an example spec
-
-   ```bash
-   # Replace `YOUR_GITHUB_USERNAME` with your own github username
-   git clone https://github.com/YOUR_GITHUB_USERNAME/terminalGPT.git terminalGPT
-   cd terminalGPT
-
-   # Add jucasoliveira/terminalGPT as a remote
-   git remote add upstream https://github.com/jucasoliveira/terminalGPT.git
-
-   # Install packages
-   npm install
-   ```
-
-3. On your terminal, type `npm run chat`. Your terminalGPT will start. 😊
-
-<br>
-
-## Extra / Remove from your computer
-
-`npx terminalgpt` doesn't install the terminalgpt package, instead it downloads the package to your pc and directly executes it from the cache.
+Note `npx terminalgpt` doesn't install the terminalgpt package, instead it downloads the package to your computer and directly executes it from the cache.
 
 You can find the package using
 
@@ -135,6 +96,10 @@ You can find the package using
 To delete the package, you can use
 
 `rm -r ~/.npm/_npx/*/node_modules/terminalgpt`
+
+## Contributing
+
+Refer to CONTRIBUTING.md 😎
 
 ## ✨ Contributors
 

--- a/bin/gpt.js
+++ b/bin/gpt.js
@@ -4,7 +4,7 @@ const { loadWithRocketGradient } = require("./gradient");
 const { getContext, addContext } = require("./context");
 
 
-const generateCompletion = async (apiKey, prompt) => {
+const generateCompletion = async (apiKey, prompt, opts) => {
   try {
     
     const configuration = new Configuration({
@@ -18,8 +18,9 @@ const generateCompletion = async (apiKey, prompt) => {
     addContext({"role": "system", "content": "Read the context, when returning the answer ,always wrapping block of code exactly within triple backticks"});
 
     const request = await openai.createChatCompletion({
-      model:"gpt-3.5-turbo",
-      messages:getContext(),
+      model: opts.engine || "gpt-3.5-turbo",
+      messages: getContext(),
+      temperature: opts.temperature ? Number(opts.temperature) : 1,
     })
       .then((res) => {
         addContext(res.data.choices[0].message);

--- a/bin/index.js
+++ b/bin/index.js
@@ -11,13 +11,8 @@ const { deleteApiKey } = require("./encrypt");
 
 commander
   .command("chat")
-  .option("-e, --engine <engine>", "GPT-3 model to use")
+  .option("-e, --engine <engine>", "GPT model to use")
   .option("-t, --temperature <temperature>", "Response temperature")
-  .option(
-    "-f,--finetunning <finetunning>",
-    "Opt in to pretrain the model with a prompt"
-  )
-  .option("-l,--limit <limit>", "The limit of prompts to train the model with")
   .option("-m,--markdown", "Show markdown in the terminal")
   .usage(`"<project-directory>" [options]`)
   .action(async (opts) => {
@@ -44,7 +39,7 @@ commander
           case "clear":
             return process.stdout.write("\x1Bc");
           default:
-            generateResponse(apiKey, prompt, response, opts.markdown);
+            generateResponse(apiKey, prompt, response, opts);
             return;
         }
       };

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -56,11 +56,12 @@ const checkBlockOfCode = async (text, prompt) => {
   }
 };
 
-const generateResponse = async (apiKey, prompt, response, isShowMarkdown = false) => {
+const generateResponse = async (apiKey, prompt, response, opts) => {
   try {
     const request = await generateCompletion(
       apiKey,
-      response.value
+      response.value,
+      opts
     );
 
     if (request == undefined || !request?.content) {
@@ -70,17 +71,17 @@ const generateResponse = async (apiKey, prompt, response, isShowMarkdown = false
     // map all choices to text
     const getText = [request.content];
 
-    console.log(`${chalk.cyan("GPT-3: ")}`);
+    console.log(`${chalk.cyan("GPT: ")}`);
 
-    if (isShowMarkdown) {
+    if (opts.isShowMarkdown) {
       console.log(marked.parse(getText[0]))
       checkBlockOfCode(getText[0], prompt);
     } else {
       // console log each character of the text with a delay and then call prompt when it finished
       let i = 0;
       const interval = setInterval(() => {
-        if (i < getText[0].length) {
-          process.stdout.write(marked.parse(getText[0][i]));
+        if (i < getText.length) {
+          process.stdout.write(marked.parse(getText[i]));
           i++;
         } else {
           clearInterval(interval);
@@ -109,7 +110,7 @@ const generateResponse = async (apiKey, prompt, response, isShowMarkdown = false
       case "yes":
       default:
         // call the function again
-        generateResponse(apiKey, prompt, response);
+        generateResponse(apiKey, prompt, response, opts);
         break;
     }
   }


### PR DESCRIPTION
Hey, thanks for maintaining this library.

I added several improvements. Mainly, I wanted to run this lib with `gpt-4` and noticed that the `--engine` option was removed, possibly unintended. I brought it back and also fixed a few issues along the way 😎.

In this PR:
- Add back `--engine` and `--temperature` options and pass them to chat completions API.
- Fix the mode where markdown is turned off. It's broken on main (but works in the latest release).
- Fix docs (clarify usage, options, fix grammar errors here and there)